### PR TITLE
Improve output format of the generated file

### DIFF
--- a/src/class-name-collector.ts
+++ b/src/class-name-collector.ts
@@ -23,7 +23,7 @@ export class ClassNameCollector {
 
     debouncedWrite = debounce(async () => {
         if (this.dest) {
-            await fs.writeFile(this.dest, this.getTypeScriptType());
+            await fs.writeFile(this.dest, this.getTypeScriptFileContent());
         }
 
         this.waiters.forEach(resolve => resolve());
@@ -60,11 +60,14 @@ export class ClassNameCollector {
         return Array.from(allUniq).sort();
     }
 
-    getTypeScriptType() {
+    getTypeScriptFileContent() {
+        const comment = '// This file is auto-generated with postcss-ts-classnames.';
+        const prefix = '  | ';
         const names = this.getClassNames()
             .map(n => `"${n}"`)
-            .join(" | ");
-        return `${this.isModule ? 'export ' : ''}type ClassNames = ${names};`;
+            .join(`\n${prefix}`);
+
+        return `${comment}\n\n${this.isModule ? 'export ' : ''}type ClassNames =\n${prefix}${names};`;
     }
 
     process(root: Root) {


### PR DESCRIPTION
By splitting the types into separate lines, editors
have easier time tokenizing and coloring the file. Comment
helps to understand that the file shouldn't be edited
manually.

The new format looks like this:

```typescript
// This file is auto-generated with postcss-ts-classnames.

export type ClassNames =
  | "\32xl\:col-span-1"
  | "\32xl\:col-span-10"
  | "\32xl\:col-span-11"
  | "\32xl\:col-span-12"
  | "\32xl\:col-span-13"
  | "\32xl\:col-span-14"
  | "\32xl\:col-span-15"
  | "\32xl\:col-span-16";
```

Fixes #4.